### PR TITLE
report when asked to stop but not running

### DIFF
--- a/lib/libpax/libpax_api.cpp
+++ b/lib/libpax/libpax_api.cpp
@@ -195,6 +195,7 @@ int libpax_counter_stop() {
     ESP_LOGI("libpax", "libpax requested to stop, but not running.");
     return -1;
   }
+  ESP_LOGI("libpax", "Stopping libpax.");
   wifi_sniffer_stop();
   stop_BLE_scan();
   xTimerStop(PaxReportTimer, 0);

--- a/lib/libpax/libpax_api.cpp
+++ b/lib/libpax/libpax_api.cpp
@@ -192,6 +192,7 @@ int libpax_counter_start() {
 
 int libpax_counter_stop() {
   if (PaxReportTimer == NULL) {
+    ESP_LOGI("libpax", "libpax requested to stop, but not running.");
     return -1;
   }
   wifi_sniffer_stop();


### PR DESCRIPTION
- Log "libpax requested to stop, but not running." when `libpax_counter_stop()` was called but libpax was not running
- Log when actually stopping